### PR TITLE
accept vector as hiccup class

### DIFF
--- a/src/hiccup_find/core.cljc
+++ b/src/hiccup_find/core.cljc
@@ -34,7 +34,9 @@ turns into
   (if (map? (second form))
     (concat (split-hiccup-symbol (first form))
             (when-let [class (-> form second :class)]
-              (map #(str "." %) (str/split class #" ")))
+              (if (string? class)
+                (map #(str "." %) (str/split class #" "))
+                (map #(str "." %) class)))
             [(str "#" (-> form second :id))])
     (split-hiccup-symbol (first form))))
 

--- a/test/hiccup_find/core_test.cljc
+++ b/test/hiccup_find/core_test.cljc
@@ -18,7 +18,12 @@
   (is (hf/hiccup-form-matches? :p.lol.haha [:p.haha {:class "lol"}]))
   (is (hf/hiccup-form-matches? :p.lol.haha [:p.haha.lol {}]))
   (is (not (hf/hiccup-form-matches? :p.lol.haha [:p {:class "lol"}])))
-  (is (hf/hiccup-form-matches? :p.lol#ok [:p {:class "lol" :id "ok"}])))
+  (is (hf/hiccup-form-matches? :p.lol#ok [:p {:class "lol" :id "ok"}]))
+
+  (is (hf/hiccup-form-matches? :p.lol [:p.haha {:class ["lol"]}]))
+  (is (hf/hiccup-form-matches? :p.haha.lol [:p.haha {:class ["lol"]}]))
+  (is (hf/hiccup-form-matches? :p.lol.haha.hihi [:p.haha {:class ["hihi" "lol"]}]))
+  (is (hf/hiccup-form-matches? :p.lol [:p.haha {:class ["hihi" "lol"]}])))
 
 (deftest test-hiccup-symbol-matches?
   (is (hiccup-symbol-matches? :p :p.class))


### PR DESCRIPTION
Add support for vectors for classes. Class in hiccup can be either string or vector.